### PR TITLE
Revert "Bump pillow from 7.0.0 to 9.0.1 in /requirements"

### DIFF
--- a/requirements/windows.txt
+++ b/requirements/windows.txt
@@ -1,2 +1,2 @@
 PySide2==5.14.1
-Pillow==9.0.1
+Pillow==7.0.0


### PR DESCRIPTION
Reverts nprezant/ImageWAO#15.
Fbs is only free up to python 3.6, can't upgrade.