### PR TITLE
Revert "Bump pillow from 7.0.0 to 9.0.1"

### DIFF
--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -3,7 +3,7 @@ fbs==0.8.6
 future==0.18.2
 macholib==1.14
 pefile==2019.4.18
-Pillow==9.0.1
+Pillow==7.0.0
 PyInstaller==3.4
 PySide2==5.14.1
 pywin32-ctypes==0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 # python==3.6
 fbs==0.8.6
 PySide2==5.14.1
-Pillow==9.0.1
+Pillow==7.0.0


### PR DESCRIPTION
Reverts nprezant/ImageWAO#16
Fbs is only free up to python 3.6, can't upgrade.